### PR TITLE
Update Ion Connect Cmd Line

### DIFF
--- a/lib/Steps.groovy
+++ b/lib/Steps.groovy
@@ -708,13 +708,9 @@ EOF
 
 
       for srcpom in \$(find . -name pom.xml); do
-        # Remove private repos from the pomfile
-        cat \$srcpom | perl -000 -ne 'print unless /org.venice.piazza/ && /pz-jobcommon/ && /dependency/' > \$pomfile
 
         echo && echo "ION OUTPUT:" && echo
-        \$ioncmd vulnerability get-vulnerabilities-for-list \
-          \$(\$ioncmd dependency resolve-dependencies-in-file --flatten --type maven \$pomfile \
-              | \$jqcmd -c .dependencies)
+		deps=$(\$ioncmd dependency resolve-dependencies-in-file --flatten --type maven \$pomfile | \$jqcmd .dependencies) && \$ioncmd --debug  vulnerability get-vulnerabilities-for-list "${deps}"
         echo
       done
 


### PR DESCRIPTION
1) We no longer need to exclude the JobCommon repository. Ion Connect has proper access to Nexus now and can properly scan our pz-jobcommon dependency.

2) The command line for ion connect has changed. I'm no Groovy expert, but the intended command line statement is:
`deps=$(ion-connect dependency resolve-dependencies-in-file --flatten --type maven pom.xml | jq .dependencies) && ion-connect --debug  vulnerability get-vulnerabilities-for-list "${deps}"`
